### PR TITLE
[ridipaper4] 리디페이퍼4 매뉴얼 섹션 구현

### DIFF
--- a/src/components/ridipaper4/Manual/Manual.tsx
+++ b/src/components/ridipaper4/Manual/Manual.tsx
@@ -1,0 +1,43 @@
+import styled from 'astroturf';
+import Button from '@/components/common/Button';
+import React from 'react';
+
+const ManualContainer = styled('section')`
+  max-width: 994px;
+  padding-top: 107px;
+  padding-bottom: 124px;
+  margin: 0 auto;
+`;
+
+const ManualTitle = styled('h2')`
+  color: #121212;
+  text-align: start;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 30px;
+  margin: 0 15px;
+  margin-bottom: 0px;
+`;
+
+const ManualButton = styled(Button)`
+  min-width: 276px;
+  min-height: 58px;
+  height: initial;
+  padding: 10px;
+  margin-top: 40px;
+  
+  color: black;
+  border: 1px solid black;
+  border-radius: 30px;
+  
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 24px;
+`;
+
+export const Manual = (): JSX.Element => (
+    <ManualContainer id="ridipaper4-manual">
+      <ManualTitle>RIDI PAPER 4 사용방법</ManualTitle>
+      <ManualButton>사용자 가이드 확인하기</ManualButton>
+    </ManualContainer>
+  );

--- a/src/components/ridipaper4/Manual/index.ts
+++ b/src/components/ridipaper4/Manual/index.ts
@@ -1,0 +1,1 @@
+export * from './Manual';


### PR DESCRIPTION
## 바로가기
1. 리팩토링 (#30)
3. 히어로 (#31)
3. 매뉴얼 (#32, 현재 PR)
4. 스펙 (#33)
5. 갤러리 (#34)
6. 리더 기능 (#35)
7. 기기 기능 (#36)
8. 디자인 소개 (#37)
9. 퀵메뉴 소개 (#38)
10. 히어로 슬라이드쇼 (#39)
11. 구매 배너 (#40)
12. 비디오 섹션 (#41)
13. 반응형 (#42)
14. 라이트박스 (#43)

## 변경사항
* 리디페이퍼 4세대 사용자 매뉴얼 섹션을 구현하였습니다.