### PR TITLE
[ridipaper4] 리디페이퍼4 스펙 섹션 구현

### DIFF
--- a/src/components/ridipaper4/Hero/Hero.tsx
+++ b/src/components/ridipaper4/Hero/Hero.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import HeroBase from '@/components/common/Hero';
 import Ridipaper4Logo from '@/svgs/ridipaper4/ridipaper4.inline.svg';
 import React from 'react';
+import { BreakPoint } from '@/styles/media';
 import { LinkButton } from '@/components/common/Button';
 
 const Background = styled('div')`
@@ -24,8 +25,8 @@ const Background = styled('div')`
     width: 100%;
     min-width: 1600px;
 
-    @media (max-width: 800px) {
-      min-width: 800px;
+    @media (max-width: ${BreakPoint.MobileMax}px) {
+      min-width: ${BreakPoint.MobileMax}px;
     }
   }
 `;
@@ -40,7 +41,7 @@ const HeroContainer = styled('div')`
   
   padding: 0 108px;
 
-  @media (max-width: 800px) {
+  @media (max-width: ${BreakPoint.MobileMax}px) {
     display: flex;
     justify-content: space-between;
     align-items: flex-end;

--- a/src/components/ridipaper4/Specs/Specs.tsx
+++ b/src/components/ridipaper4/Specs/Specs.tsx
@@ -1,0 +1,128 @@
+import styled from 'astroturf';
+import { useState } from 'react';
+import React from 'react';
+import { SpecsHeader } from './SpecsHeader';
+import { SpecsTable } from './SpecsTable';
+
+const SpecsContainer = styled('section')`
+  max-width: 1004px;
+  padding-top: 215px;
+  margin: 0 auto;
+`;
+
+const SpecsTitle = styled('h2')`
+  color: #121212;
+  text-align: start;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 30px;
+  margin: 0 20px;
+  margin-bottom: 0px;
+`;
+
+const SpecsPanelContainer = styled('div')`
+  display: none;
+  margin: 0 5px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+  width: 100%;
+  
+  &[data-is-selected="true"] {
+    display: flex;
+  }
+`;
+
+const BASIC_CONTENT = [
+  { key: 'name', name: '정식명칭', value: '리디페이퍼 4' },
+  { key: 'display-size', name: '화면크기', value: '6인치 (152.4mm)' },
+  { key: 'resolution', name: '해상도', value: '300PPI (1072x1448화소)' },
+  { key: 'weight', name: '무게', value: '173g' },
+  { key: 'size', name: '크기', value: '가로 114.08mm x 세로 156.96mm x 두께 7.94mm' },
+  { key: 'storage', name: '저장공간', value: '기본 8GB (시스템 용량 제외 약 5.72GB 사용 가능)' },
+  { key: 'external-storage', name: '확장 메모리', value: '마이크로 SD 최대 32GB 추가 가능' },
+  { key: 'battery', name: '배터리 용량', value: '1,500mAh' },
+  { key: 'charge-time', name: '충전 완료 시간', value: '약 2시간 40분 (5V 1A 충전기 기준)' },
+];
+
+const TECHINFO_CONTENT = [
+  { key: 'cpu', name: 'CPU', value: 'Exynos 850 Octa-Core 2.0GHz' },
+  { key: 'ram', name: 'RAM', value: 'LPDDR4X 3GB' },
+  { key: 'os', name: 'OS', value: '안드로이드 10' },
+  { key: 'wifi', name: '와이파이', value: '802.11a/b/g/n/ac, 2.4GHz / 5GHz' },
+  { key: 'bluetooth', name: '블루투스', value: '5.0 (Profile : A2DP, AVRCP, HID)' },
+  { key: 'safe-temperature', name: '정상 작동 온도', value: '0~40℃' },
+  { key: 'suported-file', name: '지원 파일', value: 'EPUB, TXT, PDF, ZIP' },
+];
+
+const DISPLAY_CONTENT = [
+  { key: 'type', name: '스크린 형태', value: '7" Carta 1200 E-Ink Display (논플랫 스크린)' },
+  { key: 'page', name: '페이지 넘김', value: '정전식 터치스크린 + 페이지 넘김 버튼 (2개)' },
+  { key: 'light', name: '화면 조명', value: '프론트라이트 프로 (밝기 조절 및 색 온도 조절 가능)' },
+];
+
+const EXTRA_CONTENT = [
+  {
+    key: 'extra',
+    name: '부가 기능',
+    value: [
+      '오토 슬립 (정품 하드 플립 케이스 사용 시)',
+      '화면 회전 (기기 방향에 따른 화면 자동 회전)',
+      '가로 모드 (한쪽보기, 두쪽보기 선택 가능)',
+      '퀵 버튼 (터치 잠금 모드 ON/OFF, 다양한 기능으로 할당 가능)',
+      'TTS (Text to Speech) 기능',
+      '사용자 파일 추가 (지원 파일 형식에 한함)',
+      '글자 크기, 줄 간격, 문단 간격, 문단 너비, 문단 정렬 조절',
+      '기본 글꼴 6가지 제공 (사용자 글꼴 추가 가능)'
+    ].join('\n')
+  }
+];
+
+const SpecsBasic = () => (
+  <SpecsTable rows={BASIC_CONTENT} />
+);
+
+const SpecsTechInfo = () => (
+  <SpecsTable rows={TECHINFO_CONTENT} />
+);
+
+const SpecsDisplay = () => (
+  <SpecsTable rows={DISPLAY_CONTENT} />
+);
+
+const SpecsExtra = () => (
+  <SpecsTable rows={EXTRA_CONTENT} />
+);
+
+const SPECS_ITEMS = [
+  { key: 'basic', text: '기본사양', panelId: 'ridipaper4-specs-basic', component: SpecsBasic },
+  { key: 'techinfo', text: '기술정보', panelId: 'ridipaper4-specs-techinfo', component: SpecsTechInfo },
+  { key: 'display', text: '디스플레이', panelId: 'ridipaper4-specs-display', component: SpecsDisplay },
+  { key: 'extra', text: '부가기능', panelId: 'ridipaper4-specs-extra', component: SpecsExtra },
+];
+
+export const Specs = (): JSX.Element => {
+  const items = SPECS_ITEMS;
+  const [selectedItemKey, setSelectedItemKey] = useState(items[0].key);
+  
+  return (
+    <SpecsContainer id="ridipaper4-specs">
+      <SpecsTitle>
+        RIDI PAPER 4
+        <br />
+        상세 스펙
+      </SpecsTitle>
+      
+      <SpecsHeader items={items} selectedItemKey={selectedItemKey} setSelectedItemKey={setSelectedItemKey} />
+      { items.map(({ key, panelId, component: SpecsPanel }) => (
+        <SpecsPanelContainer
+          id={panelId}
+          key={key}
+          role="tabpanel"
+          aria-selected={key === selectedItemKey}
+          data-is-selected={key === selectedItemKey}
+        >
+          <SpecsPanel />
+        </SpecsPanelContainer>
+      ))}
+    </SpecsContainer>
+  );
+};

--- a/src/components/ridipaper4/Specs/SpecsHeader.tsx
+++ b/src/components/ridipaper4/Specs/SpecsHeader.tsx
@@ -1,0 +1,84 @@
+import styled from 'astroturf';
+import React from 'react';
+
+const SpecsHeaderContainer = styled('div')`
+  position: relative;
+  width: 100%;
+  padding-top: 20px;
+  padding-bottom: 10px;
+  margin: 0 5px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const SpecsHeaderIndicator = styled('span')`
+  position: absolute;
+  top: 30px;
+  left: 7px;
+  width: 94px;
+  height: 38px;
+  border-radius: 20px;
+  
+  background: #ebebec;
+  transition: all .5s cubic-bezier(.76, .01, .27, 1.2);
+  pointer-events: none;
+`;
+
+const ITEM_WIDTH = 94;
+const ITEM_MARGIN = 7;
+const ITEM_BOX = ITEM_WIDTH + ITEM_MARGIN * 2;
+const SpecsHeaderItem = styled('button')`
+  position: relative;
+  width: ${ITEM_WIDTH}px;
+  height: 38px;
+  margin: 10px ${ITEM_MARGIN}px;
+  padding: 0 10px;
+  
+  cursor: pointer;
+  color: #bdbdbd;
+  font-size: 14px;
+  line-height: 39px;
+  font-weight: 700;
+  text-align: center;
+  transition: color .5s ease;
+  
+  &[data-is-selected="true"] {
+    color: #121212;
+  }
+`;
+
+type SpecsHeaderProps = {
+  items: { key: string, text: string, panelId: string }[];
+  selectedItemKey: string;
+  setSelectedItemKey: (newItem: string) => void;
+};
+
+export const SpecsHeader = ({ items, selectedItemKey, setSelectedItemKey }: SpecsHeaderProps): JSX.Element => {
+  const selectedItemIndex = Math.max(0, items.findIndex((item) => item.key === selectedItemKey));
+  
+  return (
+    <SpecsHeaderContainer role="tablist">
+      <SpecsHeaderIndicator
+        role="presentation"
+        style={{ transform: `translate(${ITEM_BOX * selectedItemIndex}px)` }}
+      />
+    
+      { items.map(item => (
+          <SpecsHeaderItem
+            id={`${item.panelId}-control`}
+            key={item.key}
+            role="tab"
+            aria-selected={selectedItemKey === item.key}
+            aria-controls={item.panelId}
+            data-is-selected={selectedItemKey === item.key}
+            onClick={() => setSelectedItemKey(item.key)}
+          >
+            {item.text}
+          </SpecsHeaderItem>
+      )) }
+    </SpecsHeaderContainer>
+  );
+};

--- a/src/components/ridipaper4/Specs/SpecsTable.tsx
+++ b/src/components/ridipaper4/Specs/SpecsTable.tsx
@@ -1,0 +1,43 @@
+import styled from 'astroturf';
+import React from 'react';
+
+const SpecsTableContainer = styled('dl')`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+  margin-left: 27px;
+`;
+
+const SpecsTableItemContainer = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  font-size: 14px;
+  min-height: 47px;
+`;
+
+const SpecsTableItemName = styled('dt')`
+  width: 7.5em;
+  line-height: 47px;
+`;
+
+const SpecsTableItemValue = styled('dd')`
+  flex: 1;
+  white-space: pre-line;
+  line-height: 47px;
+`;
+
+type SpecsTableProps = {
+  rows: { name: string, value: string, key: string }[];
+};
+
+export const SpecsTable = ({ rows }: SpecsTableProps) => (
+  <SpecsTableContainer>
+    { rows.map(row => (
+      <SpecsTableItemContainer key={row.key}>
+        <SpecsTableItemName>{row.name}</SpecsTableItemName>
+        <SpecsTableItemValue>{row.value}</SpecsTableItemValue>
+      </SpecsTableItemContainer>
+    )) }
+  </SpecsTableContainer>
+);

--- a/src/components/ridipaper4/Specs/index.ts
+++ b/src/components/ridipaper4/Specs/index.ts
@@ -1,0 +1,3 @@
+export * from './Specs';
+export * from './SpecsHeader';
+export * from './SpecsTable';

--- a/src/styles/media.ts
+++ b/src/styles/media.ts
@@ -1,0 +1,4 @@
+export const BreakPoint = {
+  MobileMax: 600,
+  DesktopMin: 601,
+};


### PR DESCRIPTION
## 바로가기
1. 리팩토링 (#30)
3. 히어로 (#31)
3. 매뉴얼 (#32)
4. 스펙 (#33, 현재 PR)
5. 갤러리 (#34)
6. 리더 기능 (#35)
7. 기기 기능 (#36)
8. 디자인 소개 (#37)
9. 퀵메뉴 소개 (#38)
10. 히어로 슬라이드쇼 (#39)
11. 구매 배너 (#40)
12. 비디오 섹션 (#41)
13. 반응형 (#42)
14. 라이트박스 (#43)

## 변경사항
* 리디페이퍼 4세대 상세 스펙 섹션을 구현하였습니다.