### PR TITLE
[ridipaper4 / hotfix] Hero 섹션에서 첫 이미지가 스킵되는 이슈 수정

### DIFF
--- a/src/components/ridipaper4/Hero/Hero.tsx
+++ b/src/components/ridipaper4/Hero/Hero.tsx
@@ -219,6 +219,10 @@ export const Hero = ({ showPurchase = false }): JSX.Element => {
   const nextImage = (flushedImage + 1) % usingImages.length;
 
   useEffect(() => {
+    if (currentImage === flushedImage) {
+      return;
+    }
+    
     if (!activeImage.current || !alternativeImage.current) {
       return;
     }
@@ -231,7 +235,7 @@ export const Hero = ({ showPurchase = false }): JSX.Element => {
       TRANSITION,
     );
     return () => clearTimeout(timeoutId);
-  }, [currentImage]);
+  }, [currentImage, flushedImage]);
 
   const renderBackground = useCallback(
     () => (


### PR DESCRIPTION
## 변경사항
리디페이퍼4 히어로 섹션에서 첫 이미지가 스킵되는 이슈를 수정하였습니다.

**As-Is**: `1번 이미지 (0.1초) -> 2번 이미지 (5초) -> 3번 이미지 (5초) -> 1번 이미지 (5초) ...`  
**To-Be**: `1번 이미지 (5초) -> 2번 이미지 (5초) -> 3번 이미지 (5초) -> 1번 이미지 (5초) ...`  